### PR TITLE
Mvp2 specification design

### DIFF
--- a/docs/spec/iteration7-spec.md
+++ b/docs/spec/iteration7-spec.md
@@ -1,0 +1,105 @@
+## Iteration 7 Development Spec - Sprint Craft (MVP2 Continuation)
+
+Source of truth for this iteration:
+- scope.md (MVP2 goals)
+- docs/spec/mvp2-spec.md (Iteration 7 activities)
+- docs/spec/iteration6-spec.md (style + testability bar)
+
+This spec turns Iteration 7 activities into implementable, testable requirements.
+
+---
+
+## Activity 1: Avatar visual clarity and front/back differentiation
+
+1. **Front marker mesh**
+   - **What to develop**: Add a small, deterministic "front marker" mesh on the avatar to clearly indicate the forward direction.
+   - **Definition of done**: The marker is created with a deterministic name and remains attached to the avatar pose.
+   - **Acceptance criteria (integration-testable)**:
+     - Scene contains a mesh named `player:frontMarker`.
+     - The marker is positioned in front of the torso/head relative to the avatar yaw.
+
+2. **Edge rendering for silhouette clarity**
+   - **What to develop**: Enable edge rendering on avatar meshes when Babylon supports it.
+   - **Definition of done**: Avatar body parts have edge rendering enabled without throwing in test environments.
+   - **Acceptance criteria**:
+     - When edge rendering APIs are available, meshes report edge rendering enabled or edges width set.
+     - Tests do not fail when Babylon edge APIs are missing.
+
+---
+
+## Activity 2: Movement-facing rules for W/A/S/D (single-key facing + idle yaw)
+
+1. **Most-recently-pressed key tracking**
+   - **What to develop**: Track the most-recently-pressed movement key among W/A/S/D.
+   - **Definition of done**: When multiple movement keys are held, the avatar faces the most recently pressed key direction.
+   - **Acceptance criteria (unit-testable)**:
+     - Press W then A while both are held → facing follows A.
+     - Releasing A reverts facing to W if W remains held.
+
+2. **Idle facing aligns to camera yaw**
+   - **What to develop**: When no movement keys are down, align avatar facing to camera yaw.
+   - **Definition of done**: Avatar yaw updates to match camera yaw in idle state.
+   - **Acceptance criteria (integration-testable)**:
+     - With no movement input, avatar yaw equals camera yaw after a tick.
+
+---
+
+## Activity 3: Right-arm forward pose + action swing constraint
+
+1. **Right arm base pose rules**
+   - **What to develop**: Right arm rests down at idle and points forward while moving/aiming.
+   - **Definition of done**: Base pose switches deterministically based on movement/aiming state.
+   - **Acceptance criteria (integration-testable)**:
+     - With no movement/aiming input, right arm rotation is the "down" pose.
+     - With movement/aiming active, right arm rotation is the "forward" pose.
+
+2. **Action-only swing for right arm**
+   - **What to develop**: Right arm swing triggers only on successful break/place actions.
+   - **Definition of done**: Right arm no longer swings with walk-cycle; action swing overlays base pose.
+   - **Acceptance criteria (unit-testable)**:
+     - Walking updates only left-arm swing (right swing remains zero without action).
+     - Successful break/place produces a right-arm swing impulse.
+
+---
+
+## Activity 4: Nameplate style update (transparent background + bright red text)
+
+1. **Transparent background**
+   - **What to develop**: Clear the dynamic texture with transparent background before drawing text.
+   - **Definition of done**: Nameplate renders with no black background.
+   - **Acceptance criteria (unit/integration-testable)**:
+     - The texture draw call uses a transparent background (e.g., rgba(0,0,0,0)).
+     - Dynamic texture alpha is enabled when supported by Babylon.
+
+2. **Bright red text**
+   - **What to develop**: Draw the nameplate text in bright red.
+   - **Definition of done**: Nameplate text color is red and remains readable.
+   - **Acceptance criteria**:
+     - Draw call uses a bright red color (e.g., #ff3333 or rgb(255,0,0)).
+
+---
+
+## Activity 5: Validation updates for new orientation/arm/nameplate rules
+
+1. **Unit tests**
+   - **What to develop**: Add unit tests for facing selection, right-arm swing constraints, and nameplate draw settings.
+   - **Definition of done**: Unit tests exist and cover Activity 2-4 requirements.
+   - **Acceptance criteria**:
+     - Unit tests validate most-recently-pressed facing selection.
+     - Unit tests validate right arm has no walk swing and action swing triggers.
+     - Unit tests validate nameplate draw color/background settings.
+
+2. **Integration tests**
+   - **What to develop**: Add integration tests for front marker existence, idle yaw alignment, and right arm pose behavior.
+   - **Definition of done**: Integration tests cover acceptance criteria for Activities 1-3.
+   - **Acceptance criteria**:
+     - Tests assert `player:frontMarker` exists.
+     - Tests verify avatar yaw aligns to camera yaw when idle.
+     - Tests verify right arm base pose changes between idle and moving/aiming states.
+
+---
+
+## Definition of Done (Iteration 7)
+- All Activity acceptance criteria are met.
+- Unit and integration tests exist and pass.
+- Manual test spec is documented in docs/spec/iteration7-test.md.

--- a/docs/spec/iteration7-test.md
+++ b/docs/spec/iteration7-test.md
@@ -1,0 +1,47 @@
+## Iteration 7 Manual Test List (acceptance-criteria based)
+
+Prereqs:
+- Run `npm install`
+
+---
+
+Acceptance Criteria 1 (Front marker mesh exists):
+  Test Case 1
+    Step 1: Run `npm run dev`.
+    Step 2: Open `http://localhost:5173` and enter the world.
+    Step 3: Confirm a small front marker is visible on the avatar (front/back are distinguishable).
+
+Acceptance Criteria 2 (Edge rendering for avatar silhouette):
+  Test Case 1
+    Step 1: Run `npm run dev`.
+    Step 2: Observe the avatar from multiple angles.
+    Step 3: Confirm edges appear clearer than the voxel meshes (if supported by the browser).
+
+Acceptance Criteria 3 (Most-recently-pressed movement key sets facing):
+  Test Case 1
+    Step 1: Hold W, then press A while still holding W.
+    Step 2: Confirm the avatar turns to face its left side relative to movement.
+    Step 3: Release A while holding W and confirm the avatar returns to facing forward.
+
+Acceptance Criteria 4 (Idle facing aligns to camera yaw):
+  Test Case 1
+    Step 1: Release all movement keys.
+    Step 2: Move the mouse to change camera yaw.
+    Step 3: Confirm the avatar facing matches the camera yaw when idle.
+
+Acceptance Criteria 5 (Right arm base pose rules):
+  Test Case 1
+    Step 1: Stand still without clicking or moving.
+    Step 2: Confirm the right arm rests down.
+    Step 3: Hold W or click to aim and confirm the right arm points forward.
+
+Acceptance Criteria 6 (Right arm action-only swing):
+  Test Case 1
+    Step 1: Walk forward and confirm the right arm does not swing with walking.
+    Step 2: Break or place a block successfully.
+    Step 3: Confirm the right arm swings only on the successful action.
+
+Acceptance Criteria 7 (Nameplate transparent background and red text):
+  Test Case 1
+    Step 1: Observe the nameplate above the avatar head.
+    Step 2: Confirm the text is bright red and there is no black background behind it.

--- a/docs/spec/mvp2-spec.md
+++ b/docs/spec/mvp2-spec.md
@@ -4,80 +4,73 @@ This document captures the design-approved activities and iteration plan for MVP
 
 ## Activities
 
-Activity 1 - Branding splash (centered, hides on first input)
-- Purpose: Show "Sprint Craft" prominently on load and hide after first keyboard or mouse input.
-- Risks: Overlay could interfere with HUD readability if not styled carefully.
-- Other Important Remarks: Use a centered, large, white label with a subtle shadow; remove on first input.
+Activity 1 - Avatar visual clarity and front/back differentiation
+- Purpose: Make the avatar easier to read and clearly distinguish front vs back.
+- Risks: Over-stylization could clash with the minimal look; purely visual cues are hard to test.
+- Other Important Remarks: Use lightweight, deterministic cues (edge rendering, asymmetric coloring, or a small front marker).
 
-Activity 2 - Full-body avatar with over-the-shoulder camera
-- Purpose: Render a complete avatar (head, torso, arms, legs) and shift camera to a shoulder offset.
-- Risks: Camera clipping near walls; avatar alignment drift under stance changes.
-- Other Important Remarks: Use simple primitive meshes and a camera clamp against voxels.
+Activity 2 - Movement-facing rules for W/A/S/D (single-key facing + idle yaw)
+- Purpose: Match scope: W=front, S=back, A=left side, D=right side; when not moving, align facing to camera yaw.
+- Risks: Multi-key input may cause jitter if not handled deterministically.
+- Other Important Remarks: Use most-recently-pressed key for facing when multiple keys are held.
 
-Activity 3 - Hand and arm motion tied to actions
-- Purpose: Visible arm motion for walking and block interactions.
-- Risks: Animation timing could feel off for rapid clicks.
-- Other Important Remarks: Use lightweight procedural animation with action-triggered swings.
+Activity 3 - Right-arm forward pose + action swing constraint
+- Purpose: Keep the right arm as a forward-facing cue and only swing on successful break/place.
+- Risks: Conflicts with current walk-cycle swing; requires clear base pose rules.
+- Other Important Remarks: Right arm is down at idle; forward while moving/aiming; action-only swing.
 
-Activity 4 - Nameplate over avatar head
-- Purpose: Display a user name above the avatar (example: "<User 1>").
-- Risks: Readability against bright backgrounds; billboard alignment.
-- Other Important Remarks: Use a billboarded plane with text drawn on a dynamic texture.
+Activity 4 - Nameplate style update (transparent background + bright red text)
+- Purpose: Ensure nameplate has no background and uses bright red text.
+- Risks: Red text readability on bright backgrounds; transparency may require explicit alpha settings.
+- Other Important Remarks: Explicitly clear the dynamic texture with transparent background and use bright red text.
 
-Activity 5 - Validation updates for MVP2 changes
-- Purpose: Add unit and integration tests that cover the new visuals and behaviors.
-- Risks: Visual behaviors are harder to test deterministically.
-- Other Important Remarks: Expose deterministic IDs and state for assertions.
+Activity 5 - Validation updates for new orientation/arm/nameplate rules
+- Purpose: Add unit and integration tests for avatar facing, right-arm constraints, and nameplate styling.
+- Risks: Visual cues are hard to assert; may need deterministic hooks for tests.
+- Other Important Remarks: Prefer deterministic state for assertions (facing key/yaw, arm pose, text color).
 
 ## Design
 
-Activity 1 - Branding splash (centered, hides on first input)
-- UPDATE: /workspace/index.html
-  - Add a centered, large, white "Sprint Craft" splash element in the HUD.
-  - Style for visibility and include a fade-out transition.
-- UPDATE: /workspace/src/sprint-craft/app.ts
-  - Add a one-time input listener (keyboard or mouse) to hide the splash.
-- TEST: Integration test asserts splash is visible on load and hidden on first input.
-
-Activity 2 - Full-body avatar with over-the-shoulder camera
-- NEW: /workspace/src/sprint-craft/voxels/player-avatar.ts
-  - Build a full-body avatar (head, torso, upper/lower arms, upper/lower legs).
-- UPDATE: /workspace/src/sprint-craft/voxels/player-controller.ts
-  - Expose camera target/anchor positions derived from player state.
-- UPDATE: /workspace/src/sprint-craft/voxels/voxel-demo.ts
-  - Instantiate avatar, update pose each tick, and apply shoulder camera offset with voxel clamp.
-- TEST: Integration tests verify avatar creation, height, and camera clamp behavior.
-
-Activity 3 - Hand and arm motion tied to actions
-- NEW: /workspace/src/sprint-craft/voxels/hand-animation.ts
-  - Provide procedural swing data based on movement speed and action triggers.
-- UPDATE: /workspace/src/sprint-craft/voxels/block-interaction.ts
-  - Emit action events on successful break/place.
-- UPDATE: /workspace/src/sprint-craft/voxels/voxel-demo.ts
-  - Feed movement/action signals into hand animation and apply to avatar.
-- TEST: Unit test verifies action triggers set swing state.
-
-Activity 4 - Nameplate over avatar head
-- NEW: /workspace/src/sprint-craft/ui/nameplate.ts
-  - Billboarded nameplate with a dynamic texture for text.
+Activity 1 - Avatar visual clarity and front/back differentiation
 - UPDATE: /workspace/src/sprint-craft/voxels/player-avatar.ts
-  - Provide head position for nameplate attachment.
-- UPDATE: /workspace/src/sprint-craft/voxels/voxel-demo.ts
-  - Create and update nameplate each tick.
-- TEST: Integration test verifies nameplate exists and follows avatar.
+  - Add a small front marker mesh and/or asymmetric color to distinguish front/back.
+  - Enable edge rendering on avatar parts when supported for clearer silhouettes.
+- TEST: Integration test asserts front marker mesh exists and edge rendering flags are applied when available.
 
-Activity 5 - Validation updates for MVP2 changes
-- UPDATE: /workspace/tests/iteration6.integration.test.ts
-  - Avatar creation, camera clamp, nameplate follow.
-- UPDATE: /workspace/tests/iteration6.unit.test.ts
-  - Hand animation action trigger behavior.
+Activity 2 - Movement-facing rules for W/A/S/D (single-key facing + idle yaw)
+- UPDATE: /workspace/src/sprint-craft/voxels/voxel-demo.ts
+  - Track most-recently-pressed movement key (W/A/S/D) and set avatar yaw accordingly.
+  - When no movement keys are down, align avatar yaw to camera yaw.
+- TEST: Unit test verifies most-recently-pressed rule; integration test verifies idle yaw alignment.
+
+Activity 3 - Right-arm forward pose + action swing constraint
+- UPDATE: /workspace/src/sprint-craft/voxels/hand-animation.ts
+  - Remove walk-cycle swing from the right arm; keep action-only swing on success.
+- UPDATE: /workspace/src/sprint-craft/voxels/player-avatar.ts
+  - Add base pose controls for right arm (down at idle, forward while moving/aiming).
+- UPDATE: /workspace/src/sprint-craft/voxels/voxel-demo.ts
+  - Determine moving/aiming state and apply right-arm base pose + action swing only.
+- TEST: Unit test verifies right arm has no walk swing; integration test checks idle/forward/action poses.
+
+Activity 4 - Nameplate style update (transparent background + bright red text)
+- UPDATE: /workspace/src/sprint-craft/ui/nameplate.ts
+  - Clear dynamic texture with transparent background and draw text in bright red.
+  - Ensure alpha is preserved (texture/material settings) so no black background appears.
+- TEST: Unit/integration test inspects drawText parameters and alpha settings via fake Babylon.
+
+Activity 5 - Validation updates for new orientation/arm/nameplate rules
+- NEW: /workspace/tests/iteration7.unit.test.ts
+  - Facing rule, right arm swing constraints, nameplate draw settings.
+- NEW: /workspace/tests/iteration7.integration.test.ts
+  - Front marker existence, idle facing yaw, right arm pose behavior.
+- UPDATE: /workspace/tests/fakes/fake-babylon.ts
+  - Add minimal hooks to capture nameplate draw parameters and optional edge rendering flags.
 
 ## Iteration Plan
 
-Iteration 6
-- Add a centered white "Sprint Craft" splash that hides on first keyboard or mouse input.
-- Implement full-body avatar meshes aligned to the player collider height.
-- Shift camera to a shoulder offset and clamp against voxels to prevent clipping.
-- Add procedural arm/hand animation tied to movement and break/place actions.
-- Add a nameplate above the avatar head with default text "<User 1>".
-- Extend unit and integration tests to cover new behaviors.
+Iteration 7
+- Add front/back visual cues for the avatar (front marker and/or edge rendering).
+- Implement movement-facing rules (most-recently-pressed key) and idle facing to camera yaw.
+- Update right arm pose rules (down idle, forward while moving/aiming, action-only swing).
+- Fix nameplate visuals (transparent background, bright red text).
+- Add unit and integration tests for new facing/arm/nameplate behavior.

--- a/docs/spec/sys-doc.md
+++ b/docs/spec/sys-doc.md
@@ -62,12 +62,14 @@ tests/
   iteration5.unit.test.ts
   iteration6.integration.test.ts
   iteration6.unit.test.ts
+  iteration7.integration.test.ts
+  iteration7.unit.test.ts
 ```
 
 ### Counts
 - Folders: 8 (src: 6, tests: 2)
-- Files: 41 (src: 28, tests: 13)
-- Approximate number of functions in src: ~247 (regex count of "function" and "=>" tokens in src)
+- Files: 43 (src: 28, tests: 15)
+- Approximate number of functions in src: ~259 (regex count of "function" and "=>" tokens in src)
 
 ## Program Document - Core Game Function
 **Assumption:** The exact heading template requested was not provided in the prompt; the format below uses the required bold labels (File path, Objective, Function, Objective, Logic, Parameters, Returns, Side effects & dependencies, Errors/Exceptions, Performance notes).
@@ -357,7 +359,7 @@ tests/
 **Functions:**
 - **Function:** `createNameplate(options: { babylon: BabylonApi; scene: SceneLike; text: string; name?: string }): NameplateHandle`
   - **Objective:** Build a plane mesh with a dynamic texture for the player nameplate.
-  - **Logic:** Creates a plane, attaches a dynamic texture to a material, draws text, enables billboarding, and returns a handle for updates.
+  - **Logic:** Creates a plane, attaches a dynamic texture with alpha, draws bright-red text on a transparent background, enables billboarding, and returns a handle for updates.
   - **Parameters:** `options` (`{ babylon: BabylonApi; scene: SceneLike; text: string; name?: string }`)
   - **Returns:** `NameplateHandle` - exposes `setText`, `setPosition`, `dispose`, and `meshName`.
   - **Side effects & dependencies:** Creates Babylon mesh/material/texture; mutates mesh position.
@@ -642,7 +644,7 @@ tests/
 **Functions:**
 - **Function:** `createHandAnimator(): HandAnimator`
   - **Objective:** Create a stateful animator for walk-cycle and action-triggered swings.
-  - **Logic:** Tracks walk phase and action timer, computes left/right swing angles based on movement speed and action triggers.
+  - **Logic:** Tracks walk phase and action timer, computes left-arm walk swing based on movement speed and right-arm action swing only on triggers.
   - **Parameters:** None.
   - **Returns:** `HandAnimator` - exposes `update` and `getState`.
   - **Side effects & dependencies:** Maintains internal timers and swing state.
@@ -655,7 +657,7 @@ tests/
 **Functions:**
 - **Function:** `createPlayerAvatar(options: { babylon: BabylonApi; scene: SceneLike }): PlayerAvatar`
   - **Objective:** Construct head, torso, arms, and legs as Babylon primitives and expose pose controls.
-  - **Logic:** Builds meshes, applies proportional placement, updates positions/rotations per pose, and returns handle for updates.
+  - **Logic:** Builds meshes (including a front marker), applies proportional placement, enables edge rendering when available, updates positions/rotations per pose (including right arm base pose), and returns a handle for updates.
   - **Parameters:** `options` (`{ babylon: BabylonApi; scene: SceneLike }`)
   - **Returns:** `PlayerAvatar` - exposes `setPose`, `getHeadPosition`, `getStandingHeight`, and `dispose`.
   - **Side effects & dependencies:** Creates Babylon meshes/materials; updates mesh transforms each tick.
@@ -989,7 +991,7 @@ tests/
 **Functions:**
 - **Function:** `createVoxelDemo(options: { babylon: BabylonApi; scene: SceneLike; camera: CameraLike; input: InputState; getSelectedSlot: () => number; rebuildBudgetPerFrame?: number }): VoxelDemo`
   - **Objective:** Initialize the voxel world, renderer, player controller, avatar, and per-frame tick behavior.
-  - **Logic:** Creates world, scheduler, renderer, generates initial terrain, rebuilds meshes, creates player controller and block interactor, wires hand animation and nameplate, applies a shoulder camera offset with voxel clamp, and returns a `VoxelDemo` API.
+  - **Logic:** Creates world, scheduler, renderer, generates initial terrain, rebuilds meshes, creates player controller and block interactor, tracks movement-facing key for avatar yaw, wires hand animation and nameplate, applies right-arm pose rules, clamps shoulder camera offset, and returns a `VoxelDemo` API.
   - **Parameters:** `options` (`{ babylon: BabylonApi; scene: SceneLike; camera: CameraLike; input: InputState; getSelectedSlot: () => number; rebuildBudgetPerFrame?: number }`)
   - **Returns:** `VoxelDemo`.
   - **Side effects & dependencies:** Mutates world and scene; generates chunk data; creates Babylon meshes.

--- a/docs/spec/test-doc.md
+++ b/docs/spec/test-doc.md
@@ -31,7 +31,7 @@ tests/
 ### Counts
 - Folders: 2
 - Files: 15
-- Approximate number of functions in tests: ~264 (regex count of "function" and "=>" tokens in tests)
+- Approximate number of functions in tests: ~280 (regex count of "function" and "=>" tokens in tests)
 
 ## Program Document - Test Suite
 **Assumption:** The heading template from sys-doc is reused for tests. Each test case is listed as a function-like entry using its `it("...")` description, plus any helper functions defined in the file.
@@ -999,7 +999,7 @@ tests/
 
 ### File: `tests/iteration7.integration.test.ts`
 **File path:** `tests/iteration7.integration.test.ts`
-**Objective:** Integration tests for Iteration 7 avatar facing, front marker, and right arm pose.
+**Objective:** Integration tests for Iteration 7 avatar facing, front marker, right arm action swing, and nameplate styling.
 **Functions:**
 - **Function:** `setDom(html: string): void`
   - **Objective:** Install HUD DOM and allow pointerLockElement mutation.
@@ -1028,12 +1028,39 @@ tests/
   - **Errors/Exceptions:** Assertions may throw.
   - **Performance notes:** O(1).
 
+- **Function:** `it("uses most-recently-pressed movement key for facing", ...)`
+  - **Objective:** Validate facing selection uses the most recently pressed key.
+  - **Logic:** Dispatches W then A keydown events and asserts torso yaw follows the latest key.
+  - **Parameters:** Test callback.
+  - **Returns:** `void`.
+  - **Side effects & dependencies:** DOM events, fake Babylon mesh state.
+  - **Errors/Exceptions:** Assertions may throw.
+  - **Performance notes:** O(1).
+
 - **Function:** `it("aligns facing to camera yaw and updates right arm pose on movement", ...)`
   - **Objective:** Verify idle yaw alignment and right arm base pose change on movement.
   - **Logic:** Sets camera yaw, ticks render loop, inspects torso yaw; dispatches KeyW and checks right arm rotation update.
   - **Parameters:** Test callback.
   - **Returns:** `void`.
   - **Side effects & dependencies:** DOM events, fake Babylon mesh state.
+  - **Errors/Exceptions:** Assertions may throw.
+  - **Performance notes:** O(1).
+
+- **Function:** `it("adds right arm swing on successful action", ...)`
+  - **Objective:** Ensure successful break/place triggers right arm swing.
+  - **Logic:** Creates a demo, places a block in front of the camera, simulates a mouse press, and asserts right arm rotation changes.
+  - **Parameters:** Test callback.
+  - **Returns:** `void`.
+  - **Side effects & dependencies:** Uses `createVoxelDemo`, world edits, fake Babylon mesh state.
+  - **Errors/Exceptions:** Assertions may throw.
+  - **Performance notes:** O(1).
+
+- **Function:** `it("draws bright red text on a transparent nameplate", ...)`
+  - **Objective:** Validate nameplate styling in integration context.
+  - **Logic:** Boots the app and inspects nameplate texture draw arguments for red text and transparent background.
+  - **Parameters:** Test callback.
+  - **Returns:** `void`.
+  - **Side effects & dependencies:** Uses fake Babylon DynamicTexture state.
   - **Errors/Exceptions:** Assertions may throw.
   - **Performance notes:** O(1).
 

--- a/docs/spec/test-doc.md
+++ b/docs/spec/test-doc.md
@@ -24,12 +24,14 @@ tests/
   iteration5.unit.test.ts
   iteration6.integration.test.ts
   iteration6.unit.test.ts
+  iteration7.integration.test.ts
+  iteration7.unit.test.ts
 ```
 
 ### Counts
 - Folders: 2
-- Files: 13
-- Approximate number of functions in tests: ~244 (regex count of "function" and "=>" tokens in tests)
+- Files: 15
+- Approximate number of functions in tests: ~264 (regex count of "function" and "=>" tokens in tests)
 
 ## Program Document - Test Suite
 **Assumption:** The heading template from sys-doc is reused for tests. Each test case is listed as a function-like entry using its `it("...")` description, plus any helper functions defined in the file.
@@ -992,6 +994,95 @@ tests/
   - **Parameters:** Test callback.
   - **Returns:** `void`.
   - **Side effects & dependencies:** Uses `createHandAnimator`.
+  - **Errors/Exceptions:** Assertions may throw.
+  - **Performance notes:** O(1).
+
+### File: `tests/iteration7.integration.test.ts`
+**File path:** `tests/iteration7.integration.test.ts`
+**Objective:** Integration tests for Iteration 7 avatar facing, front marker, and right arm pose.
+**Functions:**
+- **Function:** `setDom(html: string): void`
+  - **Objective:** Install HUD DOM and allow pointerLockElement mutation.
+  - **Logic:** Sets HTML and makes `pointerLockElement` writable.
+  - **Parameters:** `html` (`string`)
+  - **Returns:** `void`.
+  - **Side effects & dependencies:** DOM mutation.
+  - **Errors/Exceptions:** None explicit.
+  - **Performance notes:** O(1).
+
+- **Function:** `baseHudDom(): string`
+  - **Objective:** Provide HUD markup including brand splash and HUD slots.
+  - **Logic:** Returns template string with canvas and HUD elements.
+  - **Parameters:** None.
+  - **Returns:** `string`.
+  - **Side effects & dependencies:** None.
+  - **Errors/Exceptions:** None.
+  - **Performance notes:** O(1).
+
+- **Function:** `it("creates a front marker and enables edge rendering when supported", ...)`
+  - **Objective:** Ensure the front marker mesh exists and edge rendering flags are set.
+  - **Logic:** Boots app with fake Babylon, checks created meshes and edge flags.
+  - **Parameters:** Test callback.
+  - **Returns:** `void`.
+  - **Side effects & dependencies:** Uses fake Babylon mesh creation and edge flags.
+  - **Errors/Exceptions:** Assertions may throw.
+  - **Performance notes:** O(1).
+
+- **Function:** `it("aligns facing to camera yaw and updates right arm pose on movement", ...)`
+  - **Objective:** Verify idle yaw alignment and right arm base pose change on movement.
+  - **Logic:** Sets camera yaw, ticks render loop, inspects torso yaw; dispatches KeyW and checks right arm rotation update.
+  - **Parameters:** Test callback.
+  - **Returns:** `void`.
+  - **Side effects & dependencies:** DOM events, fake Babylon mesh state.
+  - **Errors/Exceptions:** Assertions may throw.
+  - **Performance notes:** O(1).
+
+### File: `tests/iteration7.unit.test.ts`
+**File path:** `tests/iteration7.unit.test.ts`
+**Objective:** Unit tests for Iteration 7 facing rules, right-arm swing constraints, and nameplate styling.
+**Functions:**
+- **Function:** `it("uses the most recently pressed movement key when multiple are held", ...)`
+  - **Objective:** Validate facing selection uses the most recently pressed key.
+  - **Logic:** Simulates pressed/down sets, updates last key, and asserts facing resolution.
+  - **Parameters:** Test callback.
+  - **Returns:** `void`.
+  - **Side effects & dependencies:** Uses facing helpers.
+  - **Errors/Exceptions:** Assertions may throw.
+  - **Performance notes:** O(1).
+
+- **Function:** `it("maps facing keys to camera yaw offsets", ...)`
+  - **Objective:** Ensure facing yaw offsets are correct for each key.
+  - **Logic:** Calls `facingYawFromKey` for W/A/S/D and checks offsets.
+  - **Parameters:** Test callback.
+  - **Returns:** `void`.
+  - **Side effects & dependencies:** None beyond helper calls.
+  - **Errors/Exceptions:** Assertions may throw.
+  - **Performance notes:** O(1).
+
+- **Function:** `it("keeps right arm swing at zero while walking", ...)`
+  - **Objective:** Ensure walking swing does not affect the right arm.
+  - **Logic:** Updates animator with movement and asserts right swing is zero.
+  - **Parameters:** Test callback.
+  - **Returns:** `void`.
+  - **Side effects & dependencies:** Uses `createHandAnimator`.
+  - **Errors/Exceptions:** Assertions may throw.
+  - **Performance notes:** O(1).
+
+- **Function:** `it("triggers right arm swing on action", ...)`
+  - **Objective:** Ensure action triggers produce right arm swing.
+  - **Logic:** Calls animator update with actionTriggered and asserts right swing.
+  - **Parameters:** Test callback.
+  - **Returns:** `void`.
+  - **Side effects & dependencies:** Uses `createHandAnimator`.
+  - **Errors/Exceptions:** Assertions may throw.
+  - **Performance notes:** O(1).
+
+- **Function:** `it("uses transparent background and bright red text", ...)`
+  - **Objective:** Validate nameplate draw parameters for color and transparency.
+  - **Logic:** Creates a nameplate with fake Babylon and inspects drawText args.
+  - **Parameters:** Test callback.
+  - **Returns:** `void`.
+  - **Side effects & dependencies:** Uses fake Babylon DynamicTexture state.
   - **Errors/Exceptions:** Assertions may throw.
   - **Performance notes:** O(1).
 

--- a/src/sprint-craft/ui/nameplate.ts
+++ b/src/sprint-craft/ui/nameplate.ts
@@ -9,6 +9,8 @@ export type NameplateHandle = {
 
 const DEFAULT_SIZE = { width: 1.4, height: 0.32 };
 const DEFAULT_TEXTURE = { width: 512, height: 128 };
+const NAMEPLATE_TEXT_COLOR = "#ff3333";
+const NAMEPLATE_CLEAR_COLOR = "rgba(0,0,0,0)";
 
 export function createNameplate(options: {
   babylon: BabylonApi;
@@ -42,6 +44,10 @@ export function createNameplate(options: {
         false
       )
     : null;
+  if (texture && "hasAlpha" in (texture as any)) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (texture as any).hasAlpha = true;
+  }
 
   const material =
     "StandardMaterial" in babylon
@@ -60,7 +66,7 @@ export function createNameplate(options: {
           (mat as any).disableLighting = true;
           if ("Color3" in babylon) {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (mat as any).emissiveColor = new (babylon as any).Color3(1, 1, 1);
+            (mat as any).emissiveColor = new (babylon as any).Color3(1, 0.25, 0.25);
           }
           return mat as unknown;
         })()
@@ -86,8 +92,8 @@ export function createNameplate(options: {
         null,
         null,
         "bold 64px Arial",
-        "#ffffff",
-        "transparent",
+        NAMEPLATE_TEXT_COLOR,
+        NAMEPLATE_CLEAR_COLOR,
         true
       );
     }

--- a/src/sprint-craft/voxels/hand-animation.ts
+++ b/src/sprint-craft/voxels/hand-animation.ts
@@ -50,7 +50,7 @@ export function createHandAnimator(): HandAnimator {
     const walkSwing = Math.sin(walkPhase) * WALK_SWING_AMPLITUDE * speedNorm;
     swing = {
       left: walkSwing,
-      right: -walkSwing + actionSwing
+      right: actionSwing
     };
     return swing;
   };

--- a/src/sprint-craft/voxels/player-avatar.ts
+++ b/src/sprint-craft/voxels/player-avatar.ts
@@ -14,6 +14,7 @@ type MeshLike = {
 export type PlayerAvatarParts = {
   head: MeshLike;
   torso: MeshLike;
+  frontMarker: MeshLike;
   upperArmL: MeshLike;
   lowerArmL: MeshLike;
   upperArmR: MeshLike;
@@ -31,21 +32,30 @@ export type PlayerAvatar = {
     yaw: number;
     stance: PlayerStance;
     swing: { left: number; right: number };
+    rightArmPose?: RightArmPose;
   }) => void;
   getHeadPosition: () => Vec3Like;
   getStandingHeight: () => number;
   dispose: () => void;
 };
 
+export type RightArmPose = "idle" | "forward";
+
 const DIMENSIONS = {
   head: { w: 0.35, h: 0.3, d: 0.35 },
   torso: { w: 0.5, h: 0.6, d: 0.3 },
   arm: { w: 0.18, h: 0.35, d: 0.18 },
-  leg: { w: 0.2, h: 0.45, d: 0.2 }
+  leg: { w: 0.2, h: 0.45, d: 0.2 },
+  marker: { w: 0.14, h: 0.14, d: 0.06 }
 };
 
 const STANDING_HEIGHT =
   DIMENSIONS.leg.h * 2 + DIMENSIONS.torso.h + DIMENSIONS.head.h;
+export const RIGHT_ARM_POSE_ANGLES: Record<RightArmPose, number> = {
+  idle: 0,
+  forward: -1.1
+};
+const RIGHT_ARM_LOWER_SCALE = 0.6;
 
 export function createPlayerAvatar(options: {
   babylon: BabylonApi;
@@ -75,7 +85,46 @@ export function createPlayerAvatar(options: {
         })()
       : null;
 
-  const makeBox = (name: string, size: { w: number; h: number; d: number }, parent?: MeshLike) => {
+  const markerMaterial =
+    "StandardMaterial" in babylon
+      ? (() => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const mat = new (babylon as any).StandardMaterial("playerFrontMat", scene as any);
+          if ("Color3" in babylon) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (mat as any).diffuseColor = new (babylon as any).Color3(1, 0.2, 0.2);
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (mat as any).emissiveColor = new (babylon as any).Color3(1, 0.2, 0.2);
+          }
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (mat as any).disableLighting = false;
+          return mat as unknown;
+        })()
+      : null;
+
+  const applyEdgeRendering = (mesh: MeshLike) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const m = mesh as any;
+    if (typeof m.enableEdgesRendering === "function") {
+      m.enableEdgesRendering();
+      if ("edgesWidth" in m) m.edgesWidth = 1.4;
+      if ("edgesColor" in m) {
+        if ("Color4" in babylon) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          m.edgesColor = new (babylon as any).Color4(0, 0, 0, 1);
+        } else {
+          m.edgesColor = { r: 0, g: 0, b: 0, a: 1 };
+        }
+      }
+    }
+  };
+
+  const makeBox = (
+    name: string,
+    size: { w: number; h: number; d: number },
+    parent?: MeshLike,
+    materialOverride?: unknown
+  ) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const mesh = createBox(
       name,
@@ -85,16 +134,19 @@ export function createPlayerAvatar(options: {
     if (!mesh.position) mesh.position = { x: 0, y: 0, z: 0 };
     if (!mesh.rotation) mesh.rotation = { x: 0, y: 0, z: 0 };
     if (!mesh.scaling) mesh.scaling = { x: 1, y: 1, z: 1 };
-    if (material) {
+    const appliedMaterial = materialOverride ?? material;
+    if (appliedMaterial) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (mesh as any).material = material as any;
+      (mesh as any).material = appliedMaterial as any;
     }
     if (parent) mesh.parent = parent;
+    applyEdgeRendering(mesh);
     return mesh;
   };
 
   const head = makeBox("player:head", DIMENSIONS.head);
   const torso = makeBox("player:torso", DIMENSIONS.torso);
+  const frontMarker = makeBox("player:frontMarker", DIMENSIONS.marker, undefined, markerMaterial);
   const upperArmL = makeBox("player:upperArmL", DIMENSIONS.arm);
   const lowerArmL = makeBox("player:lowerArmL", DIMENSIONS.arm);
   const upperArmR = makeBox("player:upperArmR", DIMENSIONS.arm);
@@ -108,6 +160,7 @@ export function createPlayerAvatar(options: {
   const torsoCenterY = legTotal + DIMENSIONS.torso.h / 2;
   const headCenterY = legTotal + DIMENSIONS.torso.h + DIMENSIONS.head.h / 2;
   const shoulderY = legTotal + DIMENSIONS.torso.h - 0.05;
+  const markerZ = DIMENSIONS.torso.d / 2 + DIMENSIONS.marker.d / 2 + 0.02;
 
   const armX = DIMENSIONS.torso.w / 2 + DIMENSIONS.arm.w / 2 + 0.05;
   const legX = DIMENSIONS.torso.w / 2 - DIMENSIONS.leg.w / 2 - 0.05;
@@ -119,6 +172,7 @@ export function createPlayerAvatar(options: {
   const basePositions: Record<keyof PlayerAvatarParts, Vec3Like> = {
     head: { x: 0, y: headCenterY, z: 0 },
     torso: { x: 0, y: torsoCenterY, z: 0 },
+    frontMarker: { x: 0, y: torsoCenterY + 0.05, z: markerZ },
     upperArmL: { x: -armX, y: shoulderY - DIMENSIONS.arm.h / 2, z: 0 },
     lowerArmL: { x: -armX, y: lowerArmY, z: 0 },
     upperArmR: { x: armX, y: shoulderY - DIMENSIONS.arm.h / 2, z: 0 },
@@ -132,6 +186,7 @@ export function createPlayerAvatar(options: {
   const parts: PlayerAvatarParts = {
     head,
     torso,
+    frontMarker,
     upperArmL,
     lowerArmL,
     upperArmR,
@@ -168,6 +223,7 @@ export function createPlayerAvatar(options: {
     yaw: number;
     stance: PlayerStance;
     swing: { left: number; right: number };
+    rightArmPose?: RightArmPose;
   }) => {
     const stanceHeight =
       pose.stance === "standing"
@@ -181,6 +237,7 @@ export function createPlayerAvatar(options: {
 
     applyScale(head, basePositions.head, scaleY, pose.yaw, pose.position);
     applyScale(torso, basePositions.torso, scaleY, pose.yaw, pose.position);
+    applyScale(frontMarker, basePositions.frontMarker, scaleY, pose.yaw, pose.position);
     applyScale(upperArmL, basePositions.upperArmL, scaleY, pose.yaw, pose.position);
     applyScale(upperArmR, basePositions.upperArmR, scaleY, pose.yaw, pose.position);
     applyScale(lowerArmL, basePositions.lowerArmL, scaleY, pose.yaw, pose.position);
@@ -192,6 +249,7 @@ export function createPlayerAvatar(options: {
 
     head.rotation.y = pose.yaw;
     torso.rotation.y = pose.yaw;
+    frontMarker.rotation.y = pose.yaw;
     upperArmL.rotation.y = pose.yaw;
     upperArmR.rotation.y = pose.yaw;
     lowerArmL.rotation.y = pose.yaw;
@@ -202,9 +260,11 @@ export function createPlayerAvatar(options: {
     lowerLegR.rotation.y = pose.yaw;
 
     upperArmL.rotation.x = pose.swing.left;
-    upperArmR.rotation.x = pose.swing.right;
+    const rightArmPose = pose.rightArmPose ?? "idle";
+    const baseRight = RIGHT_ARM_POSE_ANGLES[rightArmPose];
+    upperArmR.rotation.x = baseRight + pose.swing.right;
     lowerArmL.rotation.x = pose.swing.left * 0.5;
-    lowerArmR.rotation.x = pose.swing.right * 0.5;
+    lowerArmR.rotation.x = baseRight * RIGHT_ARM_LOWER_SCALE + pose.swing.right * 0.5;
   };
 
   const getHeadPosition = (): Vec3Like => {
@@ -233,6 +293,8 @@ export function createPlayerAvatar(options: {
       for (const mesh of all) mesh.dispose?.();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (material as any)?.dispose?.();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (markerMaterial as any)?.dispose?.();
     }
   };
 }

--- a/src/sprint-craft/voxels/voxel-demo.ts
+++ b/src/sprint-craft/voxels/voxel-demo.ts
@@ -24,6 +24,42 @@ export type VoxelDemo = {
   getPlayerState: () => ReturnType<typeof createDefaultPlayerState>;
 };
 
+export const MOVEMENT_KEYS = ["KeyW", "KeyA", "KeyS", "KeyD"] as const;
+export type MovementKey = (typeof MOVEMENT_KEYS)[number];
+
+const FACING_YAW_OFFSETS: Record<MovementKey, number> = {
+  KeyW: 0,
+  KeyS: Math.PI,
+  KeyA: -Math.PI / 2,
+  KeyD: Math.PI / 2
+};
+
+export function updateLastMovementKey(
+  lastKey: MovementKey | null,
+  wasPressed: (key: MovementKey) => boolean
+): MovementKey | null {
+  let next = lastKey;
+  for (const key of MOVEMENT_KEYS) {
+    if (wasPressed(key)) next = key;
+  }
+  return next;
+}
+
+export function resolveFacingKey(
+  lastKey: MovementKey | null,
+  isDown: (key: MovementKey) => boolean
+): MovementKey | null {
+  const held = MOVEMENT_KEYS.filter((key) => isDown(key));
+  if (held.length === 0) return null;
+  if (lastKey && isDown(lastKey)) return lastKey;
+  return held[0];
+}
+
+export function facingYawFromKey(cameraYaw: number, key: MovementKey | null): number {
+  if (!key) return cameraYaw;
+  return cameraYaw + FACING_YAW_OFFSETS[key];
+}
+
 export function createVoxelDemo(options: {
   babylon: BabylonApi;
   scene: SceneLike;
@@ -72,6 +108,7 @@ export function createVoxelDemo(options: {
   const nameplate = createNameplate({ babylon, scene, text: "<User 1>" });
   const handAnimator = createHandAnimator();
   let actionTriggered = false;
+  let lastMoveKey: MovementKey | null = null;
 
   const interactor = createBlockInteractor({
     input,
@@ -92,7 +129,12 @@ export function createVoxelDemo(options: {
     player.tick(dtSec);
     interactor.tick(dtSec);
 
+    lastMoveKey = updateLastMovementKey(lastMoveKey, (key) => input.wasKeyPressed(key));
+    const facingKey = resolveFacingKey(lastMoveKey, (key) => input.isKeyDown(key));
+
     const yaw = camera.rotation?.y ?? 0;
+    const avatarYaw = facingYawFromKey(yaw, facingKey);
+
     const forward = { x: Math.sin(yaw), z: Math.cos(yaw) };
     const right = { x: Math.cos(yaw), z: -Math.sin(yaw) };
     const back = { x: -forward.x, z: -forward.z };
@@ -147,11 +189,20 @@ export function createVoxelDemo(options: {
     });
     actionTriggered = false;
 
+    const isMoving = MOVEMENT_KEYS.some((key) => input.isKeyDown(key));
+    const isAiming =
+      input.isMouseDown(0) ||
+      input.isMouseDown(2) ||
+      input.wasMousePressed(0) ||
+      input.wasMousePressed(2);
+    const rightArmPose = isMoving || isAiming ? "forward" : "idle";
+
     avatar.setPose({
       position: player.state.position,
-      yaw,
+      yaw: avatarYaw,
       stance: player.state.stance,
-      swing
+      swing,
+      rightArmPose
     });
 
     const headPos = avatar.getHeadPosition();

--- a/src/sprint-craft/voxels/voxel-demo.ts
+++ b/src/sprint-craft/voxels/voxel-demo.ts
@@ -52,7 +52,7 @@ export function resolveFacingKey(
   const held = MOVEMENT_KEYS.filter((key) => isDown(key));
   if (held.length === 0) return null;
   if (lastKey && isDown(lastKey)) return lastKey;
-  return held[0];
+  return held[0] ?? null;
 }
 
 export function facingYawFromKey(cameraYaw: number, key: MovementKey | null): number {

--- a/src/sprint-craft/voxels/voxel-demo.ts
+++ b/src/sprint-craft/voxels/voxel-demo.ts
@@ -30,8 +30,8 @@ export type MovementKey = (typeof MOVEMENT_KEYS)[number];
 const FACING_YAW_OFFSETS: Record<MovementKey, number> = {
   KeyW: 0,
   KeyS: Math.PI,
-  KeyA: -Math.PI / 2,
-  KeyD: Math.PI / 2
+  KeyA: Math.PI / 2,
+  KeyD: -Math.PI / 2
 };
 
 export function updateLastMovementKey(

--- a/tests/fakes/fake-babylon.ts
+++ b/tests/fakes/fake-babylon.ts
@@ -171,12 +171,18 @@ export function createFakeBabylon(): {
     parent: Mesh | null = null;
     billboardMode = 0;
     isPickable = true;
+    edgesEnabled = false;
+    edgesWidth = 0;
+    edgesColor: Color4 | { r: number; g: number; b: number; a: number } | null = null;
     constructor(name: string, scene: FakeScene) {
       this.name = name;
       this.scene = scene;
       scene.createdMeshes.push(name);
       scene.createdMeshObjects.push(this);
       lastScene = scene;
+    }
+    enableEdgesRendering() {
+      this.edgesEnabled = true;
     }
     dispose() {
       this.disposed = true;
@@ -187,12 +193,33 @@ export function createFakeBabylon(): {
     name: string;
     size: { width: number; height: number };
     lastDrawText: string | null = null;
+    lastDrawTextArgs:
+      | {
+          text: string;
+          x: number | null;
+          y: number | null;
+          font: string;
+          color: string;
+          clearColor: string;
+          invertY: boolean;
+        }
+      | null = null;
+    hasAlpha = false;
     constructor(name: string, size: { width: number; height: number }, _scene?: unknown, _generateMipMaps?: boolean) {
       this.name = name;
       this.size = size;
     }
-    drawText(text: string) {
+    drawText(
+      text: string,
+      x: number | null = null,
+      y: number | null = null,
+      font = "",
+      color = "",
+      clearColor = "",
+      invertY = false
+    ) {
       this.lastDrawText = text;
+      this.lastDrawTextArgs = { text, x, y, font, color, clearColor, invertY };
     }
     getSize() {
       return this.size;

--- a/tests/iteration2.integration.test.ts
+++ b/tests/iteration2.integration.test.ts
@@ -40,7 +40,10 @@ describe("Iteration 2 (integration-ish)", () => {
     expect(chunkMeshes).toHaveLength(9);
 
     // Guardrail: ensure we are NOT creating per-voxel meshes.
-    expect(scene?.createdMeshes.length).toBeLessThanOrEqual(20);
+    const nonChunkBudget = 15;
+    expect(scene?.createdMeshes.length).toBeLessThanOrEqual(
+      chunkMeshes.length + nonChunkBudget
+    );
 
     // Run a few frames; should not rebuild meshes if nothing changed.
     const engine = getLastEngine();

--- a/tests/iteration7.integration.test.ts
+++ b/tests/iteration7.integration.test.ts
@@ -116,8 +116,9 @@ describe("Iteration 7: action swing + nameplate styling (integration)", () => {
     const camera = new babylon.FreeCamera("cam", new babylon.Vector3(0, 0, 0), scene);
 
     let mousePressed = false;
+    const keysDown = new Set<string>();
     const input = {
-      isKeyDown: (_code: string) => false,
+      isKeyDown: (code: string) => keysDown.has(code),
       wasKeyPressed: (_code: string) => false,
       wasKeyReleased: (_code: string) => false,
       isMouseDown: (_button: number) => false,
@@ -145,15 +146,21 @@ describe("Iteration 7: action swing + nameplate styling (integration)", () => {
     player.stance = "standing";
     camera.rotation.y = 0;
     camera.rotation.x = 0;
-    world.setVoxel(0, 3, 2, BlockId.Stone);
+    for (let y = 2; y <= 4; y += 1) {
+      world.setVoxel(0, y, 3, BlockId.Stone);
+      world.setVoxel(1, y, 3, BlockId.Stone);
+    }
 
     const sceneRef = getLastScene();
     const upperArmR = sceneRef?.createdMeshObjects.find((m) => m.name === "player:upperArmR");
+    keysDown.add("KeyW");
+    demo.tick(1 / 60);
     const baseRot = upperArmR?.rotation.x ?? 0;
 
     mousePressed = true;
     demo.tick(1 / 60);
     const actionRot = upperArmR?.rotation.x ?? 0;
+    expect(world.getVoxel(0, 3, 3)).toBe(BlockId.Air);
     expect(actionRot).toBeGreaterThan(baseRot + 0.02);
 
     demo.dispose();

--- a/tests/iteration7.integration.test.ts
+++ b/tests/iteration7.integration.test.ts
@@ -141,12 +141,12 @@ describe("Iteration 7: action swing + nameplate styling (integration)", () => {
 
     const world = demo.getWorld();
     const player = demo.getPlayerState();
-    player.position = { x: 0.5, y: 2, z: 0.5 };
+    player.position = { x: 0.5, y: 20, z: 0.5 };
     player.velocity = { x: 0, y: 0, z: 0 };
     player.stance = "standing";
     camera.rotation.y = 0;
     camera.rotation.x = 0;
-    for (let y = 2; y <= 4; y += 1) {
+    for (let y = 21; y <= 22; y += 1) {
       world.setVoxel(0, y, 3, BlockId.Stone);
       world.setVoxel(1, y, 3, BlockId.Stone);
     }
@@ -160,7 +160,7 @@ describe("Iteration 7: action swing + nameplate styling (integration)", () => {
     mousePressed = true;
     demo.tick(1 / 60);
     const actionRot = upperArmR?.rotation.x ?? 0;
-    expect(world.getVoxel(0, 3, 3)).toBe(BlockId.Air);
+    expect(world.getVoxel(0, 21, 3)).toBe(BlockId.Air);
     expect(actionRot).toBeGreaterThan(baseRot + 0.02);
 
     demo.dispose();

--- a/tests/iteration7.integration.test.ts
+++ b/tests/iteration7.integration.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { initApp } from "../src/sprint-craft/app";
+import { createFakeBabylon } from "./fakes/fake-babylon";
+
+function setDom(html: string) {
+  document.body.innerHTML = html;
+  Object.defineProperty(document, "pointerLockElement", {
+    value: null,
+    writable: true,
+    configurable: true
+  });
+}
+
+function baseHudDom() {
+  return `
+    <div id="app">
+      <canvas id="renderCanvas" tabindex="0"></canvas>
+      <div id="hud">
+        <div id="crosshair"></div>
+        <div id="brandSplash">Sprint Craft</div>
+        <div id="toast"></div>
+        <div id="help">help</div>
+        <div id="hotbar"></div>
+      </div>
+    </div>
+  `;
+}
+
+describe("Iteration 7: avatar front marker + edges (integration)", () => {
+  it("creates a front marker and enables edge rendering when supported", () => {
+    setDom(baseHudDom());
+    const { babylon, getLastEngine, getLastScene } = createFakeBabylon();
+    const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
+
+    const app = initApp({ babylon, canvas, document, window, enableDebugGround: false });
+    const engine = getLastEngine();
+    engine?.renderLoop?.();
+
+    const scene = getLastScene();
+    expect(scene?.createdMeshes).toContain("player:frontMarker");
+
+    const torso = scene?.createdMeshObjects.find((m) => m.name === "player:torso");
+    expect((torso as any)?.edgesEnabled).toBe(true);
+
+    app.dispose();
+  });
+});
+
+describe("Iteration 7: idle facing + right arm pose (integration)", () => {
+  it("aligns facing to camera yaw and updates right arm pose on movement", () => {
+    setDom(baseHudDom());
+    const { babylon, getLastEngine, getLastScene, getLastCamera } = createFakeBabylon();
+    const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
+
+    const app = initApp({ babylon, canvas, document, window, enableDebugGround: false });
+    const engine = getLastEngine();
+    const scene = getLastScene();
+    const camera = getLastCamera();
+
+    const torso = scene?.createdMeshObjects.find((m) => m.name === "player:torso");
+    const upperArmR = scene?.createdMeshObjects.find((m) => m.name === "player:upperArmR");
+
+    camera!.rotation.y = 1.1;
+    engine?.renderLoop?.();
+
+    expect(torso?.rotation.y).toBeCloseTo(camera!.rotation.y, 4);
+
+    const idleRotX = upperArmR?.rotation.x ?? 0;
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { code: "KeyW" }));
+    engine?.renderLoop?.();
+
+    const movingRotX = upperArmR?.rotation.x ?? 0;
+    expect(movingRotX).not.toBe(idleRotX);
+    expect(movingRotX).toBeLessThan(idleRotX + 0.001);
+
+    app.dispose();
+  });
+});

--- a/tests/iteration7.integration.test.ts
+++ b/tests/iteration7.integration.test.ts
@@ -67,7 +67,7 @@ describe("Iteration 7: facing rules + right arm pose (integration)", () => {
 
     window.dispatchEvent(new KeyboardEvent("keydown", { code: "KeyA" }));
     engine?.renderLoop?.();
-    expect(torso?.rotation.y).toBeCloseTo(-Math.PI / 2, 4);
+    expect(torso?.rotation.y).toBeCloseTo(Math.PI / 2, 4);
 
     window.dispatchEvent(new KeyboardEvent("keyup", { code: "KeyA" }));
     engine?.renderLoop?.();

--- a/tests/iteration7.integration.test.ts
+++ b/tests/iteration7.integration.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { initApp } from "../src/sprint-craft/app";
+import { BlockId } from "../src/sprint-craft/voxels/blocks";
+import { createVoxelDemo } from "../src/sprint-craft/voxels/voxel-demo";
 import { createFakeBabylon } from "./fakes/fake-babylon";
 
 function setDom(html: string) {
@@ -46,7 +48,34 @@ describe("Iteration 7: avatar front marker + edges (integration)", () => {
   });
 });
 
-describe("Iteration 7: idle facing + right arm pose (integration)", () => {
+describe("Iteration 7: facing rules + right arm pose (integration)", () => {
+  it("uses most-recently-pressed movement key for facing", () => {
+    setDom(baseHudDom());
+    const { babylon, getLastEngine, getLastScene, getLastCamera } = createFakeBabylon();
+    const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
+
+    const app = initApp({ babylon, canvas, document, window, enableDebugGround: false });
+    const engine = getLastEngine();
+    const scene = getLastScene();
+    const camera = getLastCamera();
+    const torso = scene?.createdMeshObjects.find((m) => m.name === "player:torso");
+
+    camera!.rotation.y = 0;
+    window.dispatchEvent(new KeyboardEvent("keydown", { code: "KeyW" }));
+    engine?.renderLoop?.();
+    expect(torso?.rotation.y).toBeCloseTo(0, 4);
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { code: "KeyA" }));
+    engine?.renderLoop?.();
+    expect(torso?.rotation.y).toBeCloseTo(-Math.PI / 2, 4);
+
+    window.dispatchEvent(new KeyboardEvent("keyup", { code: "KeyA" }));
+    engine?.renderLoop?.();
+    expect(torso?.rotation.y).toBeCloseTo(0, 4);
+
+    app.dispose();
+  });
+
   it("aligns facing to camera yaw and updates right arm pose on movement", () => {
     setDom(baseHudDom());
     const { babylon, getLastEngine, getLastScene, getLastCamera } = createFakeBabylon();
@@ -73,6 +102,78 @@ describe("Iteration 7: idle facing + right arm pose (integration)", () => {
     const movingRotX = upperArmR?.rotation.x ?? 0;
     expect(movingRotX).not.toBe(idleRotX);
     expect(movingRotX).toBeLessThan(idleRotX + 0.001);
+
+    app.dispose();
+  });
+});
+
+describe("Iteration 7: action swing + nameplate styling (integration)", () => {
+  it("adds right arm swing on successful action", () => {
+    const { babylon, getLastScene } = createFakeBabylon();
+    const canvas = document.createElement("canvas");
+    const engine = new babylon.Engine(canvas, true);
+    const scene = new babylon.Scene(engine);
+    const camera = new babylon.FreeCamera("cam", new babylon.Vector3(0, 0, 0), scene);
+
+    let mousePressed = false;
+    const input = {
+      isKeyDown: (_code: string) => false,
+      wasKeyPressed: (_code: string) => false,
+      wasKeyReleased: (_code: string) => false,
+      isMouseDown: (_button: number) => false,
+      wasMousePressed: (_button: number) => mousePressed,
+      wasMouseReleased: (_button: number) => false,
+      endFrame: () => {
+        mousePressed = false;
+      },
+      dispose: () => undefined
+    };
+
+    const demo = createVoxelDemo({
+      babylon,
+      scene,
+      camera: camera as any,
+      input: input as any,
+      getSelectedSlot: () => 1,
+      rebuildBudgetPerFrame: 0
+    });
+
+    const world = demo.getWorld();
+    const player = demo.getPlayerState();
+    player.position = { x: 0.5, y: 2, z: 0.5 };
+    player.velocity = { x: 0, y: 0, z: 0 };
+    player.stance = "standing";
+    camera.rotation.y = 0;
+    camera.rotation.x = 0;
+    world.setVoxel(0, 3, 2, BlockId.Stone);
+
+    const sceneRef = getLastScene();
+    const upperArmR = sceneRef?.createdMeshObjects.find((m) => m.name === "player:upperArmR");
+    const baseRot = upperArmR?.rotation.x ?? 0;
+
+    mousePressed = true;
+    demo.tick(1 / 60);
+    const actionRot = upperArmR?.rotation.x ?? 0;
+    expect(actionRot).toBeGreaterThan(baseRot + 0.02);
+
+    demo.dispose();
+  });
+
+  it("draws bright red text on a transparent nameplate", () => {
+    setDom(baseHudDom());
+    const { babylon, getLastEngine, getLastScene } = createFakeBabylon();
+    const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
+
+    const app = initApp({ babylon, canvas, document, window, enableDebugGround: false });
+    const engine = getLastEngine();
+    engine?.renderLoop?.();
+
+    const scene = getLastScene();
+    const nameplate = scene?.createdMeshObjects.find((m) => m.name === "player:nameplate");
+    const texture = (nameplate as any)?.material?.diffuseTexture;
+    expect(texture?.lastDrawTextArgs?.color).toBe("#ff3333");
+    expect(texture?.lastDrawTextArgs?.clearColor).toBe("rgba(0,0,0,0)");
+    expect(texture?.hasAlpha).toBe(true);
 
     app.dispose();
   });

--- a/tests/iteration7.unit.test.ts
+++ b/tests/iteration7.unit.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { createNameplate } from "../src/sprint-craft/ui/nameplate";
+import { createHandAnimator } from "../src/sprint-craft/voxels/hand-animation";
+import {
+  facingYawFromKey,
+  resolveFacingKey,
+  updateLastMovementKey,
+  type MovementKey
+} from "../src/sprint-craft/voxels/voxel-demo";
+import { createFakeBabylon } from "./fakes/fake-babylon";
+
+describe("Iteration 7: facing selection (unit)", () => {
+  it("uses the most recently pressed movement key when multiple are held", () => {
+    let last: MovementKey | null = null;
+    const pressed = new Set<MovementKey>();
+    const down = new Set<MovementKey>();
+    const wasPressed = (key: MovementKey) => pressed.has(key);
+    const isDown = (key: MovementKey) => down.has(key);
+
+    pressed.add("KeyW");
+    down.add("KeyW");
+    last = updateLastMovementKey(last, wasPressed);
+    pressed.clear();
+
+    expect(resolveFacingKey(last, isDown)).toBe("KeyW");
+
+    pressed.add("KeyA");
+    down.add("KeyA");
+    last = updateLastMovementKey(last, wasPressed);
+    pressed.clear();
+
+    expect(resolveFacingKey(last, isDown)).toBe("KeyA");
+
+    down.delete("KeyA");
+    expect(resolveFacingKey(last, isDown)).toBe("KeyW");
+  });
+
+  it("maps facing keys to camera yaw offsets", () => {
+    const yaw = 0.5;
+    expect(facingYawFromKey(yaw, "KeyW")).toBeCloseTo(yaw, 5);
+    expect(facingYawFromKey(yaw, "KeyS")).toBeCloseTo(yaw + Math.PI, 5);
+    expect(facingYawFromKey(yaw, "KeyA")).toBeCloseTo(yaw - Math.PI / 2, 5);
+    expect(facingYawFromKey(yaw, "KeyD")).toBeCloseTo(yaw + Math.PI / 2, 5);
+  });
+});
+
+describe("Iteration 7: right arm swing constraints (unit)", () => {
+  it("keeps right arm swing at zero while walking", () => {
+    const animator = createHandAnimator();
+    const swing = animator.update({ dtSec: 1 / 60, moveSpeed: 4, actionTriggered: false });
+    expect(Math.abs(swing.left)).toBeGreaterThan(0);
+    expect(Math.abs(swing.right)).toBe(0);
+  });
+
+  it("triggers right arm swing on action", () => {
+    const animator = createHandAnimator();
+    animator.update({ dtSec: 1 / 60, moveSpeed: 0, actionTriggered: false });
+    const swing = animator.update({ dtSec: 1 / 60, moveSpeed: 0, actionTriggered: true });
+    expect(Math.abs(swing.right)).toBeGreaterThan(0);
+  });
+});
+
+describe("Iteration 7: nameplate styling (unit)", () => {
+  it("uses transparent background and bright red text", () => {
+    const { babylon, getLastScene } = createFakeBabylon();
+    const canvas = document.createElement("canvas");
+    const engine = new babylon.Engine(canvas, true);
+    const scene = new babylon.Scene(engine);
+
+    const nameplate = createNameplate({ babylon, scene, text: "<User 1>" });
+    const lastScene = getLastScene();
+    const mesh = lastScene?.createdMeshObjects.find((m) => m.name === nameplate.meshName);
+    const texture = (mesh as any)?.material?.diffuseTexture;
+
+    expect(texture?.lastDrawTextArgs?.color).toBe("#ff3333");
+    expect(texture?.lastDrawTextArgs?.clearColor).toBe("rgba(0,0,0,0)");
+    expect(texture?.hasAlpha).toBe(true);
+  });
+});

--- a/tests/iteration7.unit.test.ts
+++ b/tests/iteration7.unit.test.ts
@@ -39,8 +39,8 @@ describe("Iteration 7: facing selection (unit)", () => {
     const yaw = 0.5;
     expect(facingYawFromKey(yaw, "KeyW")).toBeCloseTo(yaw, 5);
     expect(facingYawFromKey(yaw, "KeyS")).toBeCloseTo(yaw + Math.PI, 5);
-    expect(facingYawFromKey(yaw, "KeyA")).toBeCloseTo(yaw - Math.PI / 2, 5);
-    expect(facingYawFromKey(yaw, "KeyD")).toBeCloseTo(yaw + Math.PI / 2, 5);
+    expect(facingYawFromKey(yaw, "KeyA")).toBeCloseTo(yaw + Math.PI / 2, 5);
+    expect(facingYawFromKey(yaw, "KeyD")).toBeCloseTo(yaw - Math.PI / 2, 5);
   });
 });
 

--- a/wip.md
+++ b/wip.md
@@ -1,6 +1,10 @@
 # WIP
 
 - Iteration 6: MVP2 preparation for multi-player phase
+- Iteration 7: MVP2 continuation (avatar facing, nameplate, right arm)
 
 [Progress]
 - Iteration 6 - DONE (spec, implementation, tests)
+
+[Progress]
+- Iteration 7 - DONE (spec, implementation, tests, docs)


### PR DESCRIPTION
Implement Iteration 7 to enhance avatar visual clarity, movement-based facing, right-arm posing, and nameplate styling as per MVP2 specification.

---
<a href="https://cursor.com/background-agent?bcId=bc-8377e27d-ed06-489c-aa7a-311fdd45111b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8377e27d-ed06-489c-aa7a-311fdd45111b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements Iteration 7 visuals/controls and expands test coverage.
> 
> - **Avatar clarity:** Adds `player:frontMarker` and enables edge rendering on body meshes in `player-avatar.ts`
> - **Facing rules:** Tracks most-recently-pressed movement key and aligns idle facing to camera yaw in `voxel-demo.ts`
> - **Right arm behavior:** Sets base pose (idle/down vs forward on move/aim) and restricts swing to actions; removes walk-cycle swing from right arm
> - **Nameplate styling:** Transparent background with bright red text and alpha handling in `ui/nameplate.ts`
> - **Test support:** Extends `fake-babylon` (edge flags, dynamic texture args); adds `iteration7.unit.test.ts` and `iteration7.integration.test.ts`; minor guard in `iteration2.integration.test.ts`
> - **Docs:** Adds `docs/spec/iteration7-spec.md`, manual test list, and updates MVP2/system/test docs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1615472cf8362f346a8ca3c107519eb353d52e26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->